### PR TITLE
Only set current time if the video was playing

### DIFF
--- a/client/controls/appFrame.js
+++ b/client/controls/appFrame.js
@@ -381,7 +381,10 @@ class appFrame extends ui {
         const wasPaused = this._player.paused();
 
         this._player.src({ type: 'application/x-mpegURL', src: url });
-        this._player.currentTime(currentTime);
+
+        if (currentTime != 0) {
+            this._player.currentTime(currentTime);
+        }
 
         if (wasPaused) {
             this._btnAudioPlay.classList.remove('hidden');


### PR DESCRIPTION
This prevents an issue where minimizing an unplayed video would show the first frame instead of the poster image
